### PR TITLE
feat: add drift-deposit feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ dependencies = [
  "base64 0.22.1",
  "beethoven-client",
  "beethoven-core",
+ "beethoven-deposit-drift",
  "beethoven-deposit-jupiter",
  "beethoven-deposit-kamino",
  "beethoven-swap-aldrin",
@@ -611,6 +612,17 @@ dependencies = [
 name = "beethoven-core"
 version = "0.0.1"
 dependencies = [
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
+name = "beethoven-deposit-drift"
+version = "0.0.1"
+dependencies = [
+ "beethoven-core",
+ "solana-account-view",
+ "solana-address 2.0.0",
  "solana-instruction-view",
  "solana-program-error",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["deposit", "swap"]
 upstream-bpf = []
 
 # Action groups
-deposit = ["kamino-deposit", "jupiter-deposit"]
+deposit = ["kamino-deposit", "jupiter-deposit", "drift-deposit"]
 swap = [
     "perena-swap",
     "solfi-swap",
@@ -31,6 +31,7 @@ swap = [
 # Deposit protocols
 kamino-deposit = ["dep:beethoven-deposit-kamino"]
 jupiter-deposit = ["dep:beethoven-deposit-jupiter"]
+drift-deposit = ["dep:beethoven-deposit-drift"]
 
 # Swap protocols
 perena-swap = ["dep:beethoven-swap-perena"]
@@ -56,6 +57,7 @@ solana-program-error = "3.0.0"
 # Optional protocol crates
 beethoven-deposit-kamino = { path = "crates/deposit/kamino", optional = true }
 beethoven-deposit-jupiter = { path = "crates/deposit/jupiter", optional = true }
+beethoven-deposit-drift = { path = "crates/deposit/drift", optional = true }
 beethoven-swap-perena = { path = "crates/swap/perena", optional = true }
 beethoven-swap-solfi = { path = "crates/swap/solfi", optional = true }
 beethoven-swap-solfi-v2 = { path = "crates/swap/solfi-v2", optional = true }
@@ -74,6 +76,7 @@ members = [
     "crates/core",
     "crates/deposit/kamino",
     "crates/deposit/jupiter",
+    "crates/deposit/drift",
     "crates/swap/perena",
     "crates/swap/solfi",
     "crates/swap/solfi-v2",

--- a/crates/deposit/drift/Cargo.toml
+++ b/crates/deposit/drift/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "beethoven-deposit-drift"
+description = "Drift deposit implementation for Beethoven"
+version = "0.0.1"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+beethoven-core = { path = "../../core" }
+solana-account-view = "1.0.0"
+solana-address = "2.0.0"
+solana-instruction-view = "1.0.0"
+solana-program-error = "3.0.0"

--- a/crates/deposit/drift/src/lib.rs
+++ b/crates/deposit/drift/src/lib.rs
@@ -63,10 +63,6 @@ impl<'info> TryFrom<&'info [AccountView]> for DriftDepositAccounts<'info> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
-        if accounts.len() < 8 {
-            return Err(ProgramError::NotEnoughAccountKeys);
-        }
-
         let [drift_program, state, user, user_stats, authority, spot_market_vault, user_token_account, token_program, remaining_accounts @ ..] =
             accounts
         else {

--- a/crates/deposit/drift/src/lib.rs
+++ b/crates/deposit/drift/src/lib.rs
@@ -1,0 +1,188 @@
+#![no_std]
+
+use {
+    beethoven_core::Deposit,
+    core::mem::MaybeUninit,
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+pub const DRIFT_PROGRAM_ID: Address =
+    Address::from_str_const("dRiftyHA39MWEi3m9aunc5MzRF1JYuBsbn6VPcn33UH");
+const DEPOSIT_DISCRIMINATOR: [u8; 8] = [242, 35, 198, 137, 82, 225, 242, 182];
+const DEPOSIT_DATA_LEN: usize = 19;
+// balanced estimation without blowing the stack
+const MAX_DEPOSIT_ACCOUNTS: usize = 16;
+
+pub struct Drift;
+
+pub struct DriftDepositData {
+    pub market_index: u16,
+    pub reduce_only: u8,
+}
+
+impl DriftDepositData {
+    // 2 - market index
+    // 1 - reduce only
+    pub const DATA_LEN: usize = 3;
+}
+
+impl TryFrom<&[u8]> for DriftDepositData {
+    type Error = ProgramError;
+
+    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
+        if data.len() < Self::DATA_LEN {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(Self {
+            market_index: u16::from_le_bytes(data[0..2].try_into().unwrap()),
+            reduce_only: data[2],
+        })
+    }
+}
+
+pub struct DriftDepositAccounts<'info> {
+    pub drift_program: &'info AccountView,
+    pub state: &'info AccountView,
+    pub user: &'info AccountView,
+    pub user_stats: &'info AccountView,
+    pub authority: &'info AccountView,
+    pub spot_market_vault: &'info AccountView,
+    pub user_token_account: &'info AccountView,
+    pub token_program: &'info AccountView,
+    pub remaining_accounts: &'info [AccountView],
+}
+
+impl<'info> TryFrom<&'info [AccountView]> for DriftDepositAccounts<'info> {
+    type Error = ProgramError;
+
+    fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
+        if accounts.len() < 8 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        let [drift_program, state, user, user_stats, authority, spot_market_vault, user_token_account, token_program, remaining_accounts @ ..] =
+            accounts
+        else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
+        Ok(Self {
+            drift_program,
+            state,
+            user,
+            user_stats,
+            authority,
+            spot_market_vault,
+            user_token_account,
+            token_program,
+            remaining_accounts,
+        })
+    }
+}
+
+impl<'info> Deposit<'info> for Drift {
+    type Accounts = DriftDepositAccounts<'info>;
+    type Data = DriftDepositData;
+
+    fn deposit_signed(
+        ctx: &DriftDepositAccounts<'info>,
+        amount: u64,
+        data: &Self::Data,
+        signer_seeds: &[Signer],
+    ) -> ProgramResult {
+        let total_accounts = 7 + ctx.remaining_accounts.len();
+        if total_accounts > MAX_DEPOSIT_ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        let mut account_metas = MaybeUninit::<[InstructionAccount; MAX_DEPOSIT_ACCOUNTS]>::uninit();
+        let account_metas_ptr = account_metas.as_mut_ptr() as *mut InstructionAccount;
+
+        unsafe {
+            core::ptr::write(
+                account_metas_ptr,
+                InstructionAccount::readonly(ctx.state.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(1),
+                InstructionAccount::writable(ctx.user.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(2),
+                InstructionAccount::writable(ctx.user_stats.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(3),
+                InstructionAccount::writable_signer(ctx.authority.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(4),
+                InstructionAccount::writable(ctx.spot_market_vault.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(5),
+                InstructionAccount::writable(ctx.user_token_account.address()),
+            );
+            core::ptr::write(
+                account_metas_ptr.add(6),
+                InstructionAccount::readonly(ctx.token_program.address()),
+            );
+
+            for (index, account) in ctx.remaining_accounts.iter().enumerate() {
+                core::ptr::write(
+                    account_metas_ptr.add(7 + index),
+                    InstructionAccount::from(account),
+                );
+            }
+        }
+
+        let account_metas =
+            unsafe { core::slice::from_raw_parts(account_metas_ptr, total_accounts) };
+
+        let mut account_infos = [ctx.state; MAX_DEPOSIT_ACCOUNTS];
+        account_infos[1] = ctx.user;
+        account_infos[2] = ctx.user_stats;
+        account_infos[3] = ctx.authority;
+        account_infos[4] = ctx.spot_market_vault;
+        account_infos[5] = ctx.user_token_account;
+        account_infos[6] = ctx.token_program;
+        for (index, account) in ctx.remaining_accounts.iter().enumerate() {
+            account_infos[7 + index] = account;
+        }
+        let account_infos = &account_infos[..total_accounts];
+
+        let mut instruction_data = MaybeUninit::<[u8; DEPOSIT_DATA_LEN]>::uninit();
+        unsafe {
+            let ptr = instruction_data.as_mut_ptr() as *mut u8;
+            core::ptr::copy_nonoverlapping(DEPOSIT_DISCRIMINATOR.as_ptr(), ptr, 8);
+            core::ptr::copy_nonoverlapping(data.market_index.to_le_bytes().as_ptr(), ptr.add(8), 2);
+            core::ptr::copy_nonoverlapping(amount.to_le_bytes().as_ptr(), ptr.add(10), 8);
+            *ptr.add(18) = data.reduce_only;
+        }
+
+        let deposit_ix = InstructionView {
+            program_id: &DRIFT_PROGRAM_ID,
+            accounts: account_metas,
+            data: unsafe { instruction_data.assume_init_ref() },
+        };
+
+        invoke_signed_with_bounds::<MAX_DEPOSIT_ACCOUNTS>(
+            &deposit_ix,
+            account_infos,
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
+
+    fn deposit(ctx: &DriftDepositAccounts<'info>, amount: u64, data: &Self::Data) -> ProgramResult {
+        Self::deposit_signed(ctx, amount, data, &[])
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -551,6 +551,9 @@ pub enum DepositContext<'info> {
 
     #[cfg(feature = "jupiter-deposit")]
     Jupiter(crate::jupiter::JupiterEarnDepositAccounts<'info>),
+
+    #[cfg(feature = "drift-deposit")]
+    Drift(crate::drift::DriftDepositAccounts<'info>),
 }
 
 /// Protocol-specific deposit data enum for use with DepositContext
@@ -559,12 +562,14 @@ pub enum DepositData {
     Kamino(()),
     #[cfg(feature = "jupiter-deposit")]
     Jupiter(()),
+    #[cfg(feature = "drift-deposit")]
+    Drift(crate::drift::DriftDepositData),
 }
 
 impl<'a> DepositContext<'a> {
     pub fn try_from_deposit_data(
         &self,
-        _data: &'a [u8],
+        data: &'a [u8],
     ) -> Result<(DepositData, &'a [u8]), ProgramError> {
         match self {
             #[cfg(feature = "kamino-deposit")]
@@ -572,6 +577,12 @@ impl<'a> DepositContext<'a> {
 
             #[cfg(feature = "jupiter-deposit")]
             DepositContext::Jupiter(_) => Ok((DepositData::Jupiter(()), &[])),
+
+            #[cfg(feature = "drift-deposit")]
+            DepositContext::Drift(_) => Ok((
+                DepositData::Drift(crate::drift::DriftDepositData::try_from(data)?),
+                &[],
+            )),
 
             #[allow(unreachable_patterns)]
             _ => Err(ProgramError::InvalidAccountData),
@@ -586,7 +597,7 @@ impl<'info> Deposit<'info> for DepositContext<'info> {
     fn deposit_signed(
         ctx: &Self::Accounts,
         amount: u64,
-        _data: &Self::Data,
+        data: &Self::Data,
         signer_seeds: &[Signer],
     ) -> ProgramResult {
         match ctx {
@@ -598,6 +609,15 @@ impl<'info> Deposit<'info> for DepositContext<'info> {
             #[cfg(feature = "jupiter-deposit")]
             DepositContext::Jupiter(accounts) => {
                 crate::jupiter::JupiterEarn::deposit_signed(accounts, amount, &(), signer_seeds)
+            }
+
+            #[cfg(feature = "drift-deposit")]
+            DepositContext::Drift(accounts) => {
+                if let DepositData::Drift(data) = data {
+                    crate::drift::Drift::deposit_signed(accounts, amount, data, signer_seeds)
+                } else {
+                    Err(ProgramError::InvalidInstructionData)
+                }
             }
 
             #[allow(unreachable_patterns)]
@@ -631,6 +651,12 @@ pub fn try_from_deposit_context<'info>(
     ) {
         let ctx = crate::jupiter::JupiterEarnDepositAccounts::try_from(accounts)?;
         return Ok(DepositContext::Jupiter(ctx));
+    }
+
+    #[cfg(feature = "drift-deposit")]
+    if address_eq(detector_account.address(), &crate::drift::DRIFT_PROGRAM_ID) {
+        let ctx = crate::drift::DriftDepositAccounts::try_from(accounts)?;
+        return Ok(DepositContext::Drift(ctx));
     }
 
     Err(ProgramError::InvalidAccountData)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 // Re-export core traits
 pub use beethoven_core::{Deposit, Swap};
+#[cfg(feature = "drift-deposit")]
+pub use beethoven_deposit_drift as drift;
 #[cfg(feature = "jupiter-deposit")]
 pub use beethoven_deposit_jupiter as jupiter;
 // Re-export protocol crates under feature flags

--- a/tests/deposit/drift.rs
+++ b/tests/deposit/drift.rs
@@ -1,0 +1,14 @@
+use {crate::helper::*, solana_keypair::Keypair, solana_signer::Signer};
+
+#[test]
+fn test_drift_deposit() {
+    let mut svm = setup_svm();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+    // TODO: Load beethoven-test program
+    // TODO: Load drift program or mock
+    // TODO: Set up accounts from fixtures
+    // TODO: Execute deposit instruction
+    // TODO: Verify results
+}


### PR DESCRIPTION
## Summary

## Changes

- prerequisite: https://github.com/blueshift-gg/beethoven/pull/32
- add drift-deposit feature
- scaffold test (just like Jupiter and Kamino)

## Testing

- [x] `make format`
- [x] `make clippy`
- [x] `make test`
- [ ] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [x] Feature flag added and used for all protocol code
- [x] Action context enums updated
- [x] Detection logic updated
- [x] Account parsing validates count and types
- [ ] Tests added or updated
