### PR TITLE
feat: add route class and metis-route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
 name = "beethoven-core"
 version = "0.0.1"
 dependencies = [
+ "solana-account-view",
  "solana-instruction-view",
  "solana-program-error",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "beethoven-core",
  "beethoven-deposit-jupiter",
  "beethoven-deposit-kamino",
+ "beethoven-route-metis",
  "beethoven-swap-aldrin",
  "beethoven-swap-aldrin-v2",
  "beethoven-swap-futarchy",
@@ -629,6 +630,17 @@ dependencies = [
 
 [[package]]
 name = "beethoven-deposit-kamino"
+version = "0.0.1"
+dependencies = [
+ "beethoven-core",
+ "solana-account-view",
+ "solana-address 2.0.0",
+ "solana-instruction-view",
+ "solana-program-error",
+]
+
+[[package]]
+name = "beethoven-route-metis"
 version = "0.0.1"
 dependencies = [
  "beethoven-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 edition = "2021"
 
 [features]
-default = ["deposit", "swap"]
+default = ["deposit", "swap", "route"]
 
 # Test program selection (for dev-dependencies)
 upstream-bpf = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ swap = [
     "scale_vmm-swap",
     "omnipair-swap",
 ]
-
+route = [
+    "metis-route",
+]
 # Deposit protocols
 kamino-deposit = ["dep:beethoven-deposit-kamino"]
 jupiter-deposit = ["dep:beethoven-deposit-jupiter"]
@@ -45,6 +47,9 @@ gamma-swap = ["dep:beethoven-swap-gamma"]
 scale_amm-swap = ["dep:beethoven-swap-scale-amm"]
 scale_vmm-swap = ["dep:beethoven-swap-scale-vmm"]
 omnipair-swap = ["dep:beethoven-swap-omnipair"]
+
+# Route protocols
+metis-route = ["dep:beethoven-route-metis"]
 
 [dependencies]
 beethoven-core = { path = "crates/core" }
@@ -68,6 +73,7 @@ beethoven-swap-gamma = { path = "crates/swap/gamma", optional = true }
 beethoven-swap-scale-amm = { path = "crates/swap/scale-amm", optional = true }
 beethoven-swap-scale-vmm = { path = "crates/swap/scale-vmm", optional = true }
 beethoven-swap-omnipair = { path = "crates/swap/omnipair", optional = true }
+beethoven-route-metis = { path = "crates/route/metis", optional = true }
 
 [workspace]
 members = [
@@ -88,6 +94,7 @@ members = [
     "crates/swap/omnipair",
     "program-test",
     "crates/client",
+    "crates/route/metis",
 ]
 
 [dev-dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "beethoven-core"
-description = "Core traits for Beethoven - Swap and Deposit"
+description = "Core traits for Beethoven - Swap, Deposit and Route"
 version = "0.0.1"
 license = "MIT"
 edition = "2021"
 
 [dependencies]
+solana-account-view = "1.0.0"
 solana-instruction-view = { version = "1.0.0", features = ["cpi"] }
 solana-program-error = "3.0.0"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use {solana_instruction_view::cpi::Signer, solana_program_error::ProgramResult};
+use {
+    solana_account_view::AccountView, solana_instruction_view::cpi::Signer,
+    solana_program_error::ProgramResult,
+};
 
 /// Core trait for swap operations across different DEX protocols.
 ///
@@ -43,4 +46,33 @@ pub trait Deposit<'info> {
 
     /// Execute a deposit without signing (user is direct signer)
     fn deposit(ctx: &Self::Accounts, amount: u64) -> ProgramResult;
+}
+
+/// Core trait for aggregator route operations (Jupiter, Titan, OKX, etc.).
+///
+/// Each aggregator implements this trait with its specific account requirements,
+/// instruction data validation, and CPI logic. Unlike `Swap`, route operations
+/// receive raw instruction data.
+pub trait Route<'info> {
+    /// Protocol-specific accounts required for the route CPI
+    type Accounts;
+
+    /// Validate that swap_data encodes the expected amount and slippage_bps
+    fn check_amount_and_slippage(swap_data: &[u8], amount: u64, slippage_bps: u16)
+        -> ProgramResult;
+
+    /// Execute a route with PDA signing capability
+    fn route_signed(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+        signer_seeds: &[Signer],
+    ) -> ProgramResult;
+
+    /// Execute a route without signing (user is direct signer)
+    fn route(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult;
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -58,8 +58,12 @@ pub trait Route<'info> {
     type Accounts;
 
     /// Validate that swap_data encodes the expected amount and slippage_bps
-    fn check_amount_and_slippage(swap_data: &[u8], amount: u64, slippage_bps: u16)
-        -> ProgramResult;
+    fn check_amount_and_slippage(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        amount: u64,
+        slippage_bps: u16,
+    ) -> ProgramResult;
 
     /// Execute a route with PDA signing capability
     fn route_signed(

--- a/crates/route/metis/Cargo.toml
+++ b/crates/route/metis/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "beethoven-route-metis"
+description = "Metis route implementation for Beethoven"
+version = "0.0.1"
+license = "MIT"
+edition = "2021"
+
+[dependencies]
+beethoven-core = { path = "../../core" }
+solana-account-view = "1.0.0"
+solana-address = "2.0.0"
+solana-instruction-view = "1.0.0"
+solana-program-error = "3.0.0"

--- a/crates/route/metis/src/lib.rs
+++ b/crates/route/metis/src/lib.rs
@@ -1,0 +1,338 @@
+#![no_std]
+
+use {
+    beethoven_core::Route,
+    core::mem::MaybeUninit,
+    solana_account_view::AccountView,
+    solana_address::Address,
+    solana_instruction_view::{
+        cpi::{invoke_signed_with_bounds, Signer},
+        InstructionAccount, InstructionView,
+    },
+    solana_program_error::{ProgramError, ProgramResult},
+};
+
+// JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4
+pub const JUPITER_PROGRAM_ID: Address = Address::new_from_array([
+    4, 121, 213, 91, 242, 49, 192, 110, 238, 116, 197, 110, 206, 104, 21, 7, 253, 177, 178, 222,
+    163, 244, 142, 81, 2, 177, 205, 162, 86, 188, 19, 143,
+]);
+// D8cy77BBepLMngZx6ZukaTff5hCt1HrWyKk3Hnd9oitf
+pub const JUPITER_EVENT_AUTHORITY: Address = Address::new_from_array([
+    180, 63, 250, 39, 245, 215, 246, 74, 116, 192, 155, 31, 41, 88, 121, 222, 75, 9, 171, 54, 223,
+    201, 221, 81, 75, 50, 26, 167, 179, 140, 229, 232,
+]);
+
+// Instruction Discriminators
+pub const EXACT_OUT_ROUTE_DISCRIMINATOR: [u8; 8] = [208, 51, 239, 151, 123, 43, 237, 92];
+pub const ROUTE_DISCRIMINATOR: [u8; 8] = [229, 23, 203, 151, 122, 227, 173, 42];
+pub const SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR: [u8; 8] =
+    [176, 209, 105, 168, 154, 125, 69, 62];
+pub const SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR: [u8; 8] = [193, 32, 155, 51, 65, 214, 156, 129];
+const MAX_TOTAL_ACCOUNTS: usize = 255;
+
+pub struct Metis;
+
+pub struct MetisRouteAccounts<'info> {
+    pub token_program: &'info AccountView,
+    pub token_account_authority: &'info AccountView,
+    pub source_token_account: &'info AccountView,
+    pub destination_token_account: &'info AccountView,
+    pub source_mint: &'info AccountView,
+    pub destination_mint: &'info AccountView,
+    pub event_authority: &'info AccountView,
+    pub jupiter_program: &'info AccountView,
+}
+
+impl MetisRouteAccounts<'_> {
+    pub const NUM_ACCOUNTS: usize = 8;
+}
+
+impl<'info> TryFrom<&'info [AccountView]> for MetisRouteAccounts<'info> {
+    type Error = ProgramError;
+
+    fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
+        if accounts.len() < MetisRouteAccounts::NUM_ACCOUNTS {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        let [jupiter_program, token_program, token_account_authority, source_token_account, destination_token_account, source_mint, destination_mint, event_authority, ..] =
+            accounts
+        else {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        };
+
+        Ok(MetisRouteAccounts {
+            token_program,
+            token_account_authority,
+            source_token_account,
+            destination_token_account,
+            source_mint,
+            destination_mint,
+            event_authority,
+            jupiter_program,
+        })
+    }
+}
+
+impl<'info> Route<'info> for Metis {
+    type Accounts = MetisRouteAccounts<'info>;
+
+    fn check_amount_and_slippage(
+        swap_data: &[u8],
+        amount: u64,
+        slippage_bps: u16,
+    ) -> Result<(), ProgramError> {
+        let swap_data_length = swap_data.len();
+
+        if swap_data.len() < 8 {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        let bps_offset = swap_data_length - size_of::<u16>() - size_of::<u8>();
+
+        if slippage_bps
+            != u16::from_le_bytes(
+                swap_data[bps_offset..bps_offset + size_of::<u16>()]
+                    .try_into()
+                    .unwrap(),
+            )
+        {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        let amount_offset = bps_offset - size_of::<u64>() - size_of::<u64>();
+
+        if amount
+            != u64::from_le_bytes(
+                swap_data[amount_offset..amount_offset + size_of::<u64>()]
+                    .try_into()
+                    .unwrap(),
+            )
+        {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
+        Ok(())
+    }
+
+    fn route_signed(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+        signer_seeds: &[Signer],
+    ) -> ProgramResult {
+        if *ctx.jupiter_program.address() != JUPITER_PROGRAM_ID {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+
+        if *ctx.event_authority.address() != JUPITER_EVENT_AUTHORITY {
+            return Err(ProgramError::IncorrectAuthority);
+        }
+
+        let mut accounts = MaybeUninit::<[InstructionAccount; MAX_TOTAL_ACCOUNTS]>::uninit();
+        let accounts_ptr = accounts.as_mut_ptr() as *mut InstructionAccount;
+        let mut account_views = MaybeUninit::<[&AccountView; MAX_TOTAL_ACCOUNTS]>::uninit();
+        let account_views_ptr = account_views.as_mut_ptr() as *mut &AccountView;
+        let mut account_count = 0usize;
+        let mut view_count = 0usize;
+
+        macro_rules! push {
+            ($view:expr, $meta:expr) => {{
+                unsafe {
+                    core::ptr::write(accounts_ptr.add(account_count), $meta);
+                    core::ptr::write(account_views_ptr.add(view_count), $view);
+                }
+                account_count += 1;
+                view_count += 1;
+            }};
+        }
+
+        match swap_data {
+            data if data.starts_with(&EXACT_OUT_ROUTE_DISCRIMINATOR) => {
+                push!(
+                    ctx.token_program,
+                    InstructionAccount::readonly(ctx.token_program.address())
+                );
+                push!(
+                    ctx.token_account_authority,
+                    InstructionAccount::readonly_signer(ctx.token_account_authority.address())
+                );
+                push!(
+                    ctx.source_token_account,
+                    InstructionAccount::writable(ctx.source_token_account.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.source_mint,
+                    InstructionAccount::readonly(ctx.source_mint.address())
+                );
+                push!(
+                    ctx.destination_mint,
+                    InstructionAccount::readonly(ctx.destination_mint.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.event_authority,
+                    InstructionAccount::readonly(ctx.event_authority.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+
+                for account in remaining_accounts {
+                    let meta = InstructionAccount::from(account);
+                    push!(account, meta);
+                }
+            }
+            data if data.starts_with(&ROUTE_DISCRIMINATOR) => {
+                push!(
+                    ctx.token_program,
+                    InstructionAccount::readonly(ctx.token_program.address())
+                );
+                push!(
+                    ctx.token_account_authority,
+                    InstructionAccount::readonly_signer(ctx.token_account_authority.address())
+                );
+                push!(
+                    ctx.source_token_account,
+                    InstructionAccount::writable(ctx.source_token_account.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.destination_mint,
+                    InstructionAccount::readonly(ctx.destination_mint.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.event_authority,
+                    InstructionAccount::readonly(ctx.event_authority.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+
+                for account in remaining_accounts {
+                    let meta = InstructionAccount::from(account);
+                    push!(account, meta);
+                }
+            }
+            data if data.starts_with(&SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR)
+                || data.starts_with(&SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR) =>
+            {
+                let [program_authority, program_source_token_account, program_destination_token_account, ..] =
+                    remaining_accounts
+                else {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                };
+
+                push!(
+                    ctx.token_program,
+                    InstructionAccount::readonly(ctx.token_program.address())
+                );
+                push!(
+                    program_authority,
+                    InstructionAccount::readonly(program_authority.address())
+                );
+                push!(
+                    ctx.token_account_authority,
+                    InstructionAccount::readonly_signer(ctx.token_account_authority.address())
+                );
+                push!(
+                    ctx.source_token_account,
+                    InstructionAccount::writable(ctx.source_token_account.address())
+                );
+                push!(
+                    program_source_token_account,
+                    InstructionAccount::writable(program_source_token_account.address())
+                );
+                push!(
+                    program_destination_token_account,
+                    InstructionAccount::writable(program_destination_token_account.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.source_mint,
+                    InstructionAccount::readonly(ctx.source_mint.address())
+                );
+                push!(
+                    ctx.destination_mint,
+                    InstructionAccount::readonly(ctx.destination_mint.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+                push!(
+                    ctx.event_authority,
+                    InstructionAccount::readonly(ctx.event_authority.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+
+                for account in remaining_accounts.iter().skip(3) {
+                    let meta = InstructionAccount::from(account);
+                    push!(account, meta);
+                }
+            }
+            _ => return Err(ProgramError::InvalidInstructionData),
+        }
+
+        let instruction = InstructionView {
+            program_id: &JUPITER_PROGRAM_ID,
+            accounts: unsafe { core::slice::from_raw_parts(accounts_ptr, account_count) },
+            data: swap_data,
+        };
+
+        invoke_signed_with_bounds::<MAX_TOTAL_ACCOUNTS>(
+            &instruction,
+            unsafe { core::slice::from_raw_parts(account_views_ptr, view_count) },
+            signer_seeds,
+        )?;
+
+        Ok(())
+    }
+
+    fn route(
+        ctx: &MetisRouteAccounts<'info>,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult {
+        Self::route_signed(ctx, swap_data, remaining_accounts, &[])
+    }
+}

--- a/crates/route/metis/src/lib.rs
+++ b/crates/route/metis/src/lib.rs
@@ -85,6 +85,7 @@ impl<'info> Route<'info> for Metis {
     type Accounts = MetisRouteAccounts<'info>;
 
     fn check_amount_and_slippage(
+        _ctx: &Self::Accounts,
         swap_data: &[u8],
         amount: u64,
         slippage_bps: u16,

--- a/crates/route/metis/src/lib.rs
+++ b/crates/route/metis/src/lib.rs
@@ -6,7 +6,7 @@ use {
     solana_account_view::AccountView,
     solana_address::Address,
     solana_instruction_view::{
-        cpi::{invoke_signed_with_bounds, Signer},
+        cpi::{invoke_signed_with_bounds, Signer, MAX_STATIC_CPI_ACCOUNTS},
         InstructionAccount, InstructionView,
     },
     solana_program_error::{ProgramError, ProgramResult},
@@ -34,7 +34,6 @@ pub const ROUTE_V2_DISCRIMINATOR: [u8; 8] = [187, 100, 250, 204, 49, 196, 175, 2
 pub const SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR: [u8; 8] =
     [53, 96, 229, 202, 216, 187, 250, 24];
 pub const SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR: [u8; 8] = [209, 152, 83, 147, 124, 254, 216, 233];
-const MAX_TOTAL_ACCOUNTS: usize = 255;
 const DISCRIMINATOR_LEN: usize = 8;
 
 pub struct Metis;
@@ -199,9 +198,9 @@ impl<'info> Route<'info> for Metis {
             return Err(ProgramError::IncorrectAuthority);
         }
 
-        let mut accounts = MaybeUninit::<[InstructionAccount; MAX_TOTAL_ACCOUNTS]>::uninit();
+        let mut accounts = MaybeUninit::<[InstructionAccount; MAX_STATIC_CPI_ACCOUNTS]>::uninit();
         let accounts_ptr = accounts.as_mut_ptr() as *mut InstructionAccount;
-        let mut account_views = MaybeUninit::<[&AccountView; MAX_TOTAL_ACCOUNTS]>::uninit();
+        let mut account_views = MaybeUninit::<[&AccountView; MAX_STATIC_CPI_ACCOUNTS]>::uninit();
         let account_views_ptr = account_views.as_mut_ptr() as *mut &AccountView;
         let mut account_count = 0usize;
         let mut view_count = 0usize;
@@ -495,7 +494,7 @@ impl<'info> Route<'info> for Metis {
             data: swap_data,
         };
 
-        invoke_signed_with_bounds::<MAX_TOTAL_ACCOUNTS>(
+        invoke_signed_with_bounds::<MAX_STATIC_CPI_ACCOUNTS>(
             &instruction,
             unsafe { core::slice::from_raw_parts(account_views_ptr, view_count) },
             signer_seeds,

--- a/crates/route/metis/src/lib.rs
+++ b/crates/route/metis/src/lib.rs
@@ -29,7 +29,13 @@ pub const ROUTE_DISCRIMINATOR: [u8; 8] = [229, 23, 203, 151, 122, 227, 173, 42];
 pub const SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR: [u8; 8] =
     [176, 209, 105, 168, 154, 125, 69, 62];
 pub const SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR: [u8; 8] = [193, 32, 155, 51, 65, 214, 156, 129];
+pub const EXACT_OUT_ROUTE_V2_DISCRIMINATOR: [u8; 8] = [157, 138, 184, 82, 21, 244, 243, 36];
+pub const ROUTE_V2_DISCRIMINATOR: [u8; 8] = [187, 100, 250, 204, 49, 196, 175, 20];
+pub const SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR: [u8; 8] =
+    [53, 96, 229, 202, 216, 187, 250, 24];
+pub const SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR: [u8; 8] = [209, 152, 83, 147, 124, 254, 216, 233];
 const MAX_TOTAL_ACCOUNTS: usize = 255;
+const DISCRIMINATOR_LEN: usize = 8;
 
 pub struct Metis;
 
@@ -85,31 +91,93 @@ impl<'info> Route<'info> for Metis {
     ) -> Result<(), ProgramError> {
         let swap_data_length = swap_data.len();
 
-        if swap_data.len() < 8 {
+        if swap_data.len() < DISCRIMINATOR_LEN {
             return Err(ProgramError::InvalidInstructionData);
         }
 
-        let bps_offset = swap_data_length - size_of::<u16>() - size_of::<u8>();
+        let discriminator = &swap_data[..DISCRIMINATOR_LEN];
 
-        if slippage_bps
-            != u16::from_le_bytes(
-                swap_data[bps_offset..bps_offset + size_of::<u16>()]
-                    .try_into()
-                    .unwrap(),
-            )
+        if discriminator == EXACT_OUT_ROUTE_DISCRIMINATOR
+            || discriminator == ROUTE_DISCRIMINATOR
+            || discriminator == SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR
+            || discriminator == SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR
         {
-            return Err(ProgramError::InvalidInstructionData);
-        }
+            let bps_offset = swap_data_length - size_of::<u16>() - size_of::<u8>();
 
-        let amount_offset = bps_offset - size_of::<u64>() - size_of::<u64>();
+            if slippage_bps
+                != u16::from_le_bytes(
+                    swap_data[bps_offset..bps_offset + size_of::<u16>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
 
-        if amount
-            != u64::from_le_bytes(
-                swap_data[amount_offset..amount_offset + size_of::<u64>()]
-                    .try_into()
-                    .unwrap(),
-            )
+            let amount_offset = bps_offset - size_of::<u64>() - size_of::<u64>();
+
+            if amount
+                != u64::from_le_bytes(
+                    swap_data[amount_offset..amount_offset + size_of::<u64>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+        } else if discriminator == EXACT_OUT_ROUTE_V2_DISCRIMINATOR
+            || discriminator == ROUTE_V2_DISCRIMINATOR
         {
+            let amount_offset = DISCRIMINATOR_LEN;
+
+            if amount
+                != u64::from_le_bytes(
+                    swap_data[amount_offset..amount_offset + size_of::<u64>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+
+            let slippage_bps_offset = amount_offset + size_of::<u64>() + size_of::<u64>();
+
+            if slippage_bps
+                != u16::from_le_bytes(
+                    swap_data[slippage_bps_offset..slippage_bps_offset + size_of::<u16>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+        } else if discriminator == SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR
+            || discriminator == SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR
+        {
+            let amount_offset = DISCRIMINATOR_LEN + size_of::<u8>();
+
+            if amount
+                != u64::from_le_bytes(
+                    swap_data[amount_offset..amount_offset + size_of::<u64>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+
+            let slippage_bps_offset = amount_offset + size_of::<u64>() + size_of::<u64>();
+
+            if slippage_bps
+                != u16::from_le_bytes(
+                    swap_data[slippage_bps_offset..slippage_bps_offset + size_of::<u16>()]
+                        .try_into()
+                        .unwrap(),
+                )
+            {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+        } else {
             return Err(ProgramError::InvalidInstructionData);
         }
 
@@ -309,6 +377,113 @@ impl<'info> Route<'info> for Metis {
                     let meta = InstructionAccount::from(account);
                     push!(account, meta);
                 }
+            }
+            data if data.starts_with(&EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
+                || data.starts_with(&ROUTE_V2_DISCRIMINATOR) =>
+            {
+                let [source_token_program, destination_token_program, ..] = remaining_accounts
+                else {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                };
+
+                push!(
+                    ctx.token_account_authority,
+                    InstructionAccount::readonly_signer(ctx.token_account_authority.address())
+                );
+                push!(
+                    ctx.source_token_account,
+                    InstructionAccount::writable(ctx.source_token_account.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.source_mint,
+                    InstructionAccount::readonly(ctx.source_mint.address())
+                );
+                push!(
+                    ctx.destination_mint,
+                    InstructionAccount::readonly(ctx.destination_mint.address())
+                );
+                push!(
+                    source_token_program,
+                    InstructionAccount::readonly(source_token_program.address())
+                );
+                push!(
+                    destination_token_program,
+                    InstructionAccount::readonly(destination_token_program.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.event_authority,
+                    InstructionAccount::readonly(ctx.event_authority.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
+            }
+            data if data.starts_with(&SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
+                || data.starts_with(&SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR) =>
+            {
+                let [program_authority, program_source_token_account, program_destination_token_account, source_token_program, destination_token_program, ..] =
+                    remaining_accounts
+                else {
+                    return Err(ProgramError::NotEnoughAccountKeys);
+                };
+
+                push!(
+                    program_authority,
+                    InstructionAccount::readonly(program_authority.address())
+                );
+                push!(
+                    ctx.token_account_authority,
+                    InstructionAccount::readonly_signer(ctx.token_account_authority.address())
+                );
+                push!(
+                    ctx.source_token_account,
+                    InstructionAccount::writable(ctx.source_token_account.address())
+                );
+                push!(
+                    program_source_token_account,
+                    InstructionAccount::writable(program_source_token_account.address())
+                );
+                push!(
+                    program_destination_token_account,
+                    InstructionAccount::writable(program_destination_token_account.address())
+                );
+                push!(
+                    ctx.destination_token_account,
+                    InstructionAccount::writable(ctx.destination_token_account.address())
+                );
+                push!(
+                    ctx.source_mint,
+                    InstructionAccount::readonly(ctx.source_mint.address())
+                );
+                push!(
+                    ctx.destination_mint,
+                    InstructionAccount::readonly(ctx.destination_mint.address())
+                );
+                push!(
+                    source_token_program,
+                    InstructionAccount::readonly(source_token_program.address())
+                );
+                push!(
+                    destination_token_program,
+                    InstructionAccount::readonly(destination_token_program.address())
+                );
+                push!(
+                    ctx.event_authority,
+                    InstructionAccount::readonly(ctx.event_authority.address())
+                );
+                push!(
+                    ctx.jupiter_program,
+                    InstructionAccount::readonly(ctx.jupiter_program.address())
+                );
             }
             _ => return Err(ProgramError::InvalidInstructionData),
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -660,6 +660,11 @@ impl<'info> Route<'info> for RouteContext<'info> {
             || swap_data.starts_with(&crate::metis::ROUTE_DISCRIMINATOR)
             || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR)
             || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::ROUTE_V2_DISCRIMINATOR)
+            || swap_data
+                .starts_with(&crate::metis::SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR)
         {
             return crate::metis::Metis::check_amount_and_slippage(swap_data, amount, slippage_bps);
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -651,25 +651,23 @@ impl<'info> Route<'info> for RouteContext<'info> {
     type Accounts = Self;
 
     fn check_amount_and_slippage(
+        ctx: &Self::Accounts,
         swap_data: &[u8],
         amount: u64,
         slippage_bps: u16,
     ) -> ProgramResult {
-        #[cfg(feature = "metis-route")]
-        if swap_data.starts_with(&crate::metis::EXACT_OUT_ROUTE_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::ROUTE_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::ROUTE_V2_DISCRIMINATOR)
-            || swap_data
-                .starts_with(&crate::metis::SHARED_ACCOUNTS_EXACT_OUT_ROUTE_V2_DISCRIMINATOR)
-            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_ROUTE_V2_DISCRIMINATOR)
-        {
-            return crate::metis::Metis::check_amount_and_slippage(swap_data, amount, slippage_bps);
-        }
+        match ctx {
+            #[cfg(feature = "metis-route")]
+            RouteContext::Metis(accounts) => crate::metis::Metis::check_amount_and_slippage(
+                accounts,
+                swap_data,
+                amount,
+                slippage_bps,
+            ),
 
-        Err(ProgramError::InvalidInstructionData)
+            #[allow(unreachable_patterns)]
+            _ => Err(ProgramError::InvalidAccountData),
+        }
     }
 
     fn route_signed(

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,5 @@
 use {
-    crate::Swap,
+    crate::{Route, Swap},
     solana_account_view::AccountView,
     solana_address::address_eq,
     solana_instruction_view::cpi::Signer,
@@ -639,4 +639,98 @@ pub fn try_from_deposit_context<'info>(
     }
 
     Err(ProgramError::InvalidAccountData)
+}
+
+// Typed context for route operations, discriminated by protocol
+pub enum RouteContext<'info> {
+    #[cfg(feature = "metis-route")]
+    Metis(crate::metis::MetisRouteAccounts<'info>),
+}
+
+impl<'info> Route<'info> for RouteContext<'info> {
+    type Accounts = Self;
+
+    fn check_amount_and_slippage(
+        swap_data: &[u8],
+        amount: u64,
+        slippage_bps: u16,
+    ) -> ProgramResult {
+        #[cfg(feature = "metis-route")]
+        if swap_data.starts_with(&crate::metis::EXACT_OUT_ROUTE_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::ROUTE_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_EXACT_OUT_ROUTE_DISCRIMINATOR)
+            || swap_data.starts_with(&crate::metis::SHARED_ACCOUNTS_ROUTE_DISCRIMINATOR)
+        {
+            return crate::metis::Metis::check_amount_and_slippage(swap_data, amount, slippage_bps);
+        }
+
+        Err(ProgramError::InvalidInstructionData)
+    }
+
+    fn route_signed(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+        signer_seeds: &[Signer],
+    ) -> ProgramResult {
+        match ctx {
+            #[cfg(feature = "metis-route")]
+            RouteContext::Metis(accounts) => crate::metis::Metis::route_signed(
+                accounts,
+                swap_data,
+                remaining_accounts,
+                signer_seeds,
+            ),
+
+            #[allow(unreachable_patterns)]
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    fn route(
+        ctx: &Self::Accounts,
+        swap_data: &[u8],
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult {
+        Self::route_signed(ctx, swap_data, remaining_accounts, &[])
+    }
+}
+
+/// Detect the protocol from the first account, parse the route context,
+/// and return both the context and the remaining (unconsumed) accounts.
+pub fn try_from_route_context<'info>(
+    accounts: &'info [AccountView],
+) -> Result<(RouteContext<'info>, &'info [AccountView]), ProgramError> {
+    let detector_account = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+    #[cfg(feature = "metis-route")]
+    {
+        let n = crate::metis::MetisRouteAccounts::NUM_ACCOUNTS;
+        if address_eq(
+            detector_account.address(),
+            &crate::metis::JUPITER_PROGRAM_ID,
+        ) {
+            if accounts.len() < n {
+                return Err(ProgramError::NotEnoughAccountKeys);
+            }
+            let (mine, rest) = accounts.split_at(n);
+            let ctx = crate::metis::MetisRouteAccounts::try_from(mine)?;
+            return Ok((RouteContext::Metis(ctx), rest));
+        }
+    }
+
+    Err(ProgramError::InvalidAccountData)
+}
+
+pub fn route_signed(
+    accounts: &[AccountView],
+    swap_data: &[u8],
+    signer_seeds: &[Signer],
+) -> ProgramResult {
+    let (ctx, remaining) = try_from_route_context(accounts)?;
+    RouteContext::route_signed(&ctx, swap_data, remaining, signer_seeds)
+}
+
+pub fn route(accounts: &[AccountView], swap_data: &[u8]) -> ProgramResult {
+    route_signed(accounts, swap_data, &[])
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 #![no_std]
 
 // Re-export core traits
-pub use beethoven_core::{Deposit, Swap};
+pub use beethoven_core::{Deposit, Route, Swap};
 #[cfg(feature = "jupiter-deposit")]
 pub use beethoven_deposit_jupiter as jupiter;
 // Re-export protocol crates under feature flags
 #[cfg(feature = "kamino-deposit")]
 pub use beethoven_deposit_kamino as kamino;
+#[cfg(feature = "metis-route")]
+pub use beethoven_route_metis as metis;
 #[cfg(feature = "aldrin-swap")]
 pub use beethoven_swap_aldrin as aldrin;
 #[cfg(feature = "aldrin_v2-swap")]


### PR DESCRIPTION
## Summary

## Changes

- added a new `Route` class for agnostic aggregator program swaps
- added Metis as part of first Route crate (only V1 route instructions supported at the moment)
- no tests added yet

## Testing

- [x] `make format`
- [x] `make clippy`
- [ ] `make test`
- [ ] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [x] Feature flag added and used for all protocol code
- [x] Action context enums updated
- [x] Detection logic updated
- [x] Account parsing validates count and types
- [ ] Tests added or updated
