### PR TITLE
feat: add remaining accounts for Deposit trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
 name = "beethoven-core"
 version = "0.0.1"
 dependencies = [
+ "solana-account-view",
  "solana-instruction-view",
  "solana-program-error",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,5 +6,6 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+solana-account-view = "1.0.0"
 solana-instruction-view = { version = "1.0.0", features = ["cpi"] }
 solana-program-error = "3.0.0"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use {solana_instruction_view::cpi::Signer, solana_program_error::ProgramResult};
+use {
+    solana_account_view::AccountView, solana_instruction_view::cpi::Signer,
+    solana_program_error::ProgramResult,
+};
 
 /// Core trait for swap operations across different DEX protocols.
 ///
@@ -39,8 +42,17 @@ pub trait Deposit<'info> {
     type Accounts;
 
     /// Execute a deposit with PDA signing capability
-    fn deposit_signed(ctx: &Self::Accounts, amount: u64, signer_seeds: &[Signer]) -> ProgramResult;
+    fn deposit_signed(
+        ctx: &Self::Accounts,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+        signer_seeds: &[Signer],
+    ) -> ProgramResult;
 
     /// Execute a deposit without signing (user is direct signer)
-    fn deposit(ctx: &Self::Accounts, amount: u64) -> ProgramResult;
+    fn deposit(
+        ctx: &Self::Accounts,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult;
 }

--- a/crates/deposit/jupiter/src/lib.rs
+++ b/crates/deposit/jupiter/src/lib.rs
@@ -38,11 +38,15 @@ pub struct JupiterEarnDepositAccounts<'info> {
     pub system_program: &'info AccountView,
 }
 
+impl<'info> JupiterEarnDepositAccounts<'info> {
+    pub const NUM_ACCOUNTS: usize = 18;
+}
+
 impl<'info> TryFrom<&'info [AccountView]> for JupiterEarnDepositAccounts<'info> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
-        if accounts.len() < 18 {
+        if accounts.len() < Self::NUM_ACCOUNTS {
             return Err(ProgramError::NotEnoughAccountKeys);
         }
 
@@ -81,6 +85,7 @@ impl<'info> Deposit<'info> for JupiterEarn {
     fn deposit_signed(
         ctx: &JupiterEarnDepositAccounts<'info>,
         amount: u64,
+        _remaining_accounts: &[AccountView],
         signer_seeds: &[Signer],
     ) -> ProgramResult {
         let accounts = [
@@ -143,7 +148,11 @@ impl<'info> Deposit<'info> for JupiterEarn {
         Ok(())
     }
 
-    fn deposit(ctx: &JupiterEarnDepositAccounts<'info>, amount: u64) -> ProgramResult {
-        Self::deposit_signed(ctx, amount, &[])
+    fn deposit(
+        ctx: &JupiterEarnDepositAccounts<'info>,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult {
+        Self::deposit_signed(ctx, amount, remaining_accounts, &[])
     }
 }

--- a/crates/deposit/kamino/src/lib.rs
+++ b/crates/deposit/kamino/src/lib.rs
@@ -43,11 +43,15 @@ pub struct KaminoDepositAccounts<'info> {
     pub reserve_accounts: &'info [AccountView],
 }
 
+impl<'info> KaminoDepositAccounts<'info> {
+    pub const NUM_ACCOUNTS: usize = 19;
+}
+
 impl<'info> TryFrom<&'info [AccountView]> for KaminoDepositAccounts<'info> {
     type Error = ProgramError;
 
     fn try_from(accounts: &'info [AccountView]) -> Result<Self, Self::Error> {
-        if accounts.len() < 19 {
+        if accounts.len() < Self::NUM_ACCOUNTS {
             return Err(ProgramError::NotEnoughAccountKeys);
         }
 
@@ -97,6 +101,7 @@ impl<'info> Deposit<'info> for Kamino {
     fn deposit_signed(
         ctx: &KaminoDepositAccounts<'info>,
         amount: u64,
+        _remaining_accounts: &[AccountView],
         signer_seeds: &[Signer],
     ) -> ProgramResult {
         // Refresh reserves
@@ -260,7 +265,11 @@ impl<'info> Deposit<'info> for Kamino {
         Ok(())
     }
 
-    fn deposit(ctx: &KaminoDepositAccounts<'info>, amount: u64) -> ProgramResult {
-        Self::deposit_signed(ctx, amount, &[])
+    fn deposit(
+        ctx: &KaminoDepositAccounts<'info>,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult {
+        Self::deposit_signed(ctx, amount, remaining_accounts, &[])
     }
 }

--- a/program-test/src/deposit.rs
+++ b/program-test/src/deposit.rs
@@ -27,22 +27,25 @@ impl TryFrom<&[u8]> for DepositInstructionData {
 pub struct DepositInstruction<'a> {
     pub accounts: DepositContext<'a>,
     pub data: DepositInstructionData,
+    pub remaining_accounts: &'a [AccountView],
 }
 
 impl<'a> TryFrom<(&'a [AccountView], &[u8])> for DepositInstruction<'a> {
     type Error = ProgramError;
 
     fn try_from((accounts, data): (&'a [AccountView], &[u8])) -> Result<Self, Self::Error> {
+        let (ctx, remaining_accounts) = try_from_deposit_context(accounts)?;
         Ok(Self {
-            accounts: try_from_deposit_context(accounts)?,
+            accounts: ctx,
             data: DepositInstructionData::try_from(data)?,
+            remaining_accounts,
         })
     }
 }
 
 impl<'a> DepositInstruction<'a> {
     pub fn process(&self) -> ProgramResult {
-        DepositContext::deposit(&self.accounts, self.data.amount)
+        DepositContext::deposit(&self.accounts, self.data.amount, self.remaining_accounts)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -593,31 +593,46 @@ pub enum DepositContext<'info> {
 impl<'info> Deposit<'info> for DepositContext<'info> {
     type Accounts = Self;
 
-    fn deposit_signed(ctx: &Self::Accounts, amount: u64, signer_seeds: &[Signer]) -> ProgramResult {
+    fn deposit_signed(
+        ctx: &Self::Accounts,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+        signer_seeds: &[Signer],
+    ) -> ProgramResult {
         match ctx {
             #[cfg(feature = "kamino-deposit")]
-            DepositContext::Kamino(accounts) => {
-                crate::kamino::Kamino::deposit_signed(accounts, amount, signer_seeds)
-            }
+            DepositContext::Kamino(accounts) => crate::kamino::Kamino::deposit_signed(
+                accounts,
+                amount,
+                remaining_accounts,
+                signer_seeds,
+            ),
 
             #[cfg(feature = "jupiter-deposit")]
-            DepositContext::Jupiter(accounts) => {
-                crate::jupiter::JupiterEarn::deposit_signed(accounts, amount, signer_seeds)
-            }
+            DepositContext::Jupiter(accounts) => crate::jupiter::JupiterEarn::deposit_signed(
+                accounts,
+                amount,
+                remaining_accounts,
+                signer_seeds,
+            ),
 
             #[allow(unreachable_patterns)]
             _ => Err(ProgramError::InvalidAccountData),
         }
     }
 
-    fn deposit(ctx: &Self::Accounts, amount: u64) -> ProgramResult {
-        Self::deposit_signed(ctx, amount, &[])
+    fn deposit(
+        ctx: &Self::Accounts,
+        amount: u64,
+        remaining_accounts: &[AccountView],
+    ) -> ProgramResult {
+        Self::deposit_signed(ctx, amount, remaining_accounts, &[])
     }
 }
 
 pub fn try_from_deposit_context<'info>(
     accounts: &'info [AccountView],
-) -> Result<DepositContext<'info>, ProgramError> {
+) -> Result<(DepositContext<'info>, &'info [AccountView]), ProgramError> {
     let detector_account = accounts.first().ok_or(ProgramError::NotEnoughAccountKeys)?;
 
     #[cfg(feature = "kamino-deposit")]
@@ -625,8 +640,17 @@ pub fn try_from_deposit_context<'info>(
         detector_account.address(),
         &crate::kamino::KAMINO_LEND_PROGRAM_ID,
     ) {
-        let ctx = crate::kamino::KaminoDepositAccounts::try_from(accounts)?;
-        return Ok(DepositContext::Kamino(ctx));
+        use crate::kamino::KaminoDepositAccounts;
+
+        let n = KaminoDepositAccounts::NUM_ACCOUNTS;
+
+        if accounts.len() < n {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        let (mine, rest) = accounts.split_at(n);
+        let ctx = KaminoDepositAccounts::try_from(mine)?;
+        return Ok((DepositContext::Kamino(ctx), rest));
     }
 
     #[cfg(feature = "jupiter-deposit")]
@@ -634,8 +658,17 @@ pub fn try_from_deposit_context<'info>(
         detector_account.address(),
         &crate::jupiter::JUPITER_EARN_PROGRAM_ID,
     ) {
-        let ctx = crate::jupiter::JupiterEarnDepositAccounts::try_from(accounts)?;
-        return Ok(DepositContext::Jupiter(ctx));
+        use crate::jupiter::JupiterEarnDepositAccounts;
+
+        let n = JupiterEarnDepositAccounts::NUM_ACCOUNTS;
+
+        if accounts.len() < n {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+
+        let (mine, rest) = accounts.split_at(n);
+        let ctx = JupiterEarnDepositAccounts::try_from(mine)?;
+        return Ok((DepositContext::Jupiter(ctx), rest));
     }
 
     Err(ProgramError::InvalidAccountData)


### PR DESCRIPTION
## Summary

## Changes

- added `remaining_accounts` field to `Deposit` trait to accept extra accounts (required in deposit instruction from some protocols such as Carrot)

## Testing

- [x] `make format`
- [x] `make clippy`
- [x] `make test`
- [ ] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [ ] Feature flag added and used for all protocol code
- [ ] Action context enums updated
- [ ] Detection logic updated
- [ ] Account parsing validates count and types
- [ ] Tests added or updated
