### PR TITLE
chore: Disable run_test_upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
   rust_test_upstream:
     name: Tests upstream
     runs-on: ubuntu-latest
+    if: false  # This job is disabled until upstream is fixed
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Disable the tests using upstream util fixed https://github.com/blueshift-gg/sbpf-linker/issues/29

