### PR TITLE
fix: fix upstream access violations turning lto off and turn on upstream ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
   rust_test_upstream:
     name: Tests upstream
     runs-on: ubuntu-latest
-    if: false  # This job is disabled until upstream is fixed
+    if: true 
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5

--- a/program-test/.cargo/config.toml
+++ b/program-test/.cargo/config.toml
@@ -10,6 +10,8 @@ rustflags = [
     "link-arg=--llvm-args=-bpf-stack-size=4096",
     "-C",
     "relocation-model=static",
+    "-C",
+    "lto=off"
 ]
 
 [alias]


### PR DESCRIPTION
# Problem 
As we saw in replicating this issue: https://github.com/blueshift-gg/sbpf-linker/issues/29 upstream tests were failing with access violation even that the test logic itself it's correct.

# Findings

What was causing the issue is that the tests we have a variable length memory copy from the cpi call, and when LTO is turned on the memcpy implementation from compiler-builtins was being dropped, resulting in a access violation.

# Solution 
Disable LTO for upstream test harness