### PR TITLE
feat: use u16 for `SwapProtocolTag`

### DIFF
--- a/program-test/src/multi_swap.rs
+++ b/program-test/src/multi_swap.rs
@@ -10,7 +10,7 @@ use {
 /// Per swap (repeated num_swaps times):
 ///   [in_amount: u64 LE]
 ///   [min_out_amount: u64 LE]
-///   [swap_leg_header: 4 bytes]
+///   [swap_leg_header: 5 bytes]
 ///   [extra_data: exact byte length from the header]
 ///
 /// Accounts are a flat concatenation. Each swap consumes its fixed account

--- a/program-test/src/route.rs
+++ b/program-test/src/route.rs
@@ -12,7 +12,7 @@ use {
 /// [8..16]  - minimum_final_out_amount (u64, little-endian)
 /// [16]     - num_legs (u8)
 /// Per leg (repeated num_legs times):
-///   [swap_leg_header: 4 bytes]
+///   [swap_leg_header: 5 bytes]
 ///   [extra_data: exact byte length from the header]
 pub struct RouteInstructionData<'a> {
     pub initial_in_amount: u64,

--- a/program-test/src/swap.rs
+++ b/program-test/src/swap.rs
@@ -3,7 +3,7 @@ use {
     pinocchio::{error::ProgramError, AccountView, ProgramResult},
 };
 
-const SWAP_LEG_HEADER_LEN: usize = 4;
+const SWAP_LEG_HEADER_LEN: usize = 5;
 
 /// Instruction data for Swap
 ///
@@ -53,9 +53,12 @@ fn split_data_checked(data: &[u8], count: usize) -> Result<(&[u8], &[u8]), Progr
 
 pub(crate) fn parse_swap_leg_header(data: &[u8]) -> Result<(SwapLegHeader, &[u8]), ProgramError> {
     let (header_bytes, remaining_data) = split_data_checked(data, SWAP_LEG_HEADER_LEN)?;
-    let protocol_tag = SwapProtocolTag::from_byte(header_bytes[0])?;
-    let remaining_accounts_len = header_bytes[1] as usize;
-    let extra_data_len = u16::from_le_bytes([header_bytes[2], header_bytes[3]]) as usize;
+    let protocol_tag = SwapProtocolTag::from_discriminator(u16::from_le_bytes([
+        header_bytes[0],
+        header_bytes[1],
+    ]))?;
+    let remaining_accounts_len = header_bytes[2] as usize;
+    let extra_data_len = u16::from_le_bytes([header_bytes[3], header_bytes[4]]) as usize;
 
     Ok((
         SwapLegHeader {

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use {
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u8)]
+#[repr(u16)]
 pub enum SwapProtocolTag {
     Perena = 0,
     SolFi = 1,
@@ -26,7 +26,7 @@ pub enum SwapProtocolTag {
 }
 
 impl SwapProtocolTag {
-    pub fn from_byte(value: u8) -> Result<Self, ProgramError> {
+    pub fn from_discriminator(value: u16) -> Result<Self, ProgramError> {
         match value {
             0 => Ok(Self::Perena),
             1 => Ok(Self::SolFi),
@@ -66,11 +66,11 @@ impl SwapProtocolTag {
     }
 }
 
-impl TryFrom<u8> for SwapProtocolTag {
+impl TryFrom<u16> for SwapProtocolTag {
     type Error = ProgramError;
 
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Self::from_byte(value)
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Self::from_discriminator(value)
     }
 }
 

--- a/tests/helper.rs
+++ b/tests/helper.rs
@@ -298,7 +298,7 @@ fn append_swap_leg_header(
         "extra data length does not fit in u16",
     );
 
-    data.push(protocol_tag as u8);
+    data.extend_from_slice(&(protocol_tag as u16).to_le_bytes());
     data.push(remaining_accounts_len as u8);
     data.extend_from_slice(&(extra_data_len as u16).to_le_bytes());
 }

--- a/tests/swap/tagged.rs
+++ b/tests/swap/tagged.rs
@@ -48,8 +48,8 @@ fn build_accounts(
 }
 
 #[test]
-fn test_swap_protocol_tag_invalid_byte_fails() {
-    let err = SwapProtocolTag::from_byte(255).unwrap_err();
+fn test_swap_protocol_tag_invalid_discriminator_fails() {
+    let err = SwapProtocolTag::from_discriminator(u16::MAX).unwrap_err();
     assert_eq!(err, ProgramError::InvalidInstructionData);
 }
 


### PR DESCRIPTION
## Summary

## Changes

- 

## Testing

- [ ] `make format`
- [ ] `make clippy`
- [ ] `make test`
- [ ] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [ ] Feature flag added and used for all protocol code
- [ ] Action context enums updated
- [ ] Detection logic updated
- [ ] Account parsing validates count and types
- [ ] Tests added or updated
