### PR TITLE
fix: remove platform fee ta address check for scale swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4700,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "solana-zero-copy"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a91404c7de468dd80658cdb5d894ec803d1092ea6e2bfdf84eee6f07559c0d"
+checksum = "8ea15126ebdc7e270c50d43884369af9f51d2308156d46a18e351522a164844d"
 dependencies = [
  "borsh",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "spl-associated-token-account",
+ "spl-associated-token-account-interface",
  "spl-token-2022-interface",
  "spl-token-interface",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-signer",
  "solana-transaction",
- "spl-associated-token-account",
  "spl-associated-token-account-interface",
  "spl-token-2022-interface",
  "spl-token-interface",
@@ -4826,38 +4825,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "spl-associated-token-account"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0242277e290c023de8826f504abcf9206b3cd4e18d9ace4ec59a698b2828e88b"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-account-info",
- "solana-cpi",
- "solana-instruction",
- "solana-msg",
- "solana-program-entrypoint",
- "solana-program-error",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-system-interface 2.0.0",
- "solana-sysvar",
- "spl-associated-token-account-interface",
- "spl-token-2022-interface",
- "spl-token-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "spl-associated-token-account-interface"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
 dependencies = [
- "borsh",
  "solana-instruction",
  "solana-pubkey 3.0.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ solana-transaction = "3.0.2"
 spl-token-2022-interface = "2.1.0"
 spl-token-interface = "2"
 spl-associated-token-account = "8.0.0"
+spl-associated-token-account-interface = "2.0.0"
 thiserror = "2"
 tokio = "1"
 
@@ -191,6 +192,7 @@ beethoven-client = { workspace = true, features = [
 solana-rpc-client.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 spl-associated-token-account.workspace = true
+spl-associated-token-account-interface.workspace = true
 spl-token-2022-interface.workspace = true
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ solana-signer = "3.0.0"
 solana-transaction = "3.0.2"
 spl-token-2022-interface = "2.1.0"
 spl-token-interface = "2"
-spl-associated-token-account = "8.0.0"
 spl-associated-token-account-interface = "2.0.0"
 thiserror = "2"
 tokio = "1"
@@ -191,7 +190,6 @@ beethoven-client = { workspace = true, features = [
 ] }
 solana-rpc-client.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-spl-associated-token-account.workspace = true
 spl-associated-token-account-interface.workspace = true
 spl-token-2022-interface.workspace = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,8 +150,9 @@ solana-rpc-client-api = "3"
 solana-sdk-ids = "3.1.0"
 solana-signer = "3.0.0"
 solana-transaction = "3.0.2"
-spl-token-2022-interface = "2"
+spl-token-2022-interface = "2.1.0"
 spl-token-interface = "2"
+spl-associated-token-account = "8.0.0"
 thiserror = "2"
 tokio = "1"
 
@@ -189,8 +190,8 @@ beethoven-client = { workspace = true, features = [
 ] }
 solana-rpc-client.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-spl-associated-token-account = "8.0.0"
-spl-token-2022-interface = "2.1.0"
+spl-associated-token-account.workspace = true
+spl-token-2022-interface.workspace = true
 
 [profile.release]
 opt-level = 3

--- a/crates/client/tests/swap/scale_amm.rs
+++ b/crates/client/tests/swap/scale_amm.rs
@@ -13,7 +13,6 @@ const MINT_B: Address = address!("7j5Zo8vzDTN8qJhWSFY9RWPE76rVRXMkqvGLeaWqcyz9")
 const POOL: Address = address!("AZDqVz1TiKYGcMhaYKBMoCnRH6bXXqoxuZNR4dLL8B8K");
 const PLATFORM_CONFIG: Address = address!("232KbYciAe6ma2VCB6gQyofix8qQwyZd2WYVhpNx8SyR");
 const OWNER: Address = address!("BXfXDZh5HfyyPPHT5xYUVXWve5oJ2cY2P2Y6VyKwoqGg");
-const PLATFORM_FEE_TA_A: Address = address!("5otzrfbppNE1j6m7ptWkAcu5gs1nwj5ZQKQVwFFHQAHv");
 const VAULT_A: Address = address!("5Lsuh97Dnzsj9wp2DspyodwmUTX2ABiFYqCRtH7Ym65o");
 const VAULT_B: Address = address!("ENpu9WqhnEzUSQzhEqVx6LtpXoexmRqjWYAGYYfhDGnt");
 const FEE_BENEFICIARY_ATA: Address = address!("7XRb5qdYdCh1QUp6WZtHGtyGgwVnuu8BPS3fr2FvXboD");
@@ -83,10 +82,7 @@ async fn test_scale_amm_resolve_with_known_pool() {
     assert!(accounts[9].is_writable);
 
     // Platform fee ta a
-    assert_eq!(
-        accounts[10].pubkey, PLATFORM_FEE_TA_A,
-        "platform_fee_ta_a ATA"
-    );
+    // address dependent on config fee beneficiary
     assert!(accounts[10].is_writable);
 
     // Token program a
@@ -170,10 +166,7 @@ async fn test_scale_amm_resolve_flipped_mints() {
     assert!(accounts[9].is_writable);
 
     // Platform fee ta a
-    assert_eq!(
-        accounts[10].pubkey, PLATFORM_FEE_TA_A,
-        "platform_fee_ta_a ATA"
-    );
+    // address dependent on config fee beneficiary
     assert!(accounts[10].is_writable);
 
     // Token program a

--- a/crates/client/tests/swap/scale_vmm.rs
+++ b/crates/client/tests/swap/scale_vmm.rs
@@ -11,7 +11,6 @@ use {
 const WSOL_MINT: Address = address!("So11111111111111111111111111111111111111112");
 const MINT_B: Address = address!("3CYBUFXzQ7GJiYoxMfrFjsPNVaSkp2vVFXXLefb57chr");
 const PAIR: Address = address!("BWnowWbMBTfsLzTKgZM7vnh8SxbutJA2HB4z7Labswkb");
-const PLATFORM_FEE_TA_A: Address = address!("5otzrfbppNE1j6m7ptWkAcu5gs1nwj5ZQKQVwFFHQAHv");
 const VAULT_A: Address = address!("Tf8aks7NB82QXob8NAoorzrPFHwkuPoZ9GVLYNLjYYZ");
 const VAULT_B: Address = address!("AaP7zPXf22rpmX27n4t6ohRDPLx7mcXDeodFN9rmbhQh");
 const PLATFORM_CONFIG: Address = address!("8DxXv6ikV38rCepX3esVCHMb2wMnnnXpp7xYasGSc6bo");
@@ -82,10 +81,7 @@ async fn test_scale_vmm_resolve_with_known_pair() {
     assert!(accounts[8].is_writable);
 
     // Platform fee ta a
-    assert_eq!(
-        accounts[9].pubkey, PLATFORM_FEE_TA_A,
-        "platform_fee_ta_a ATA"
-    );
+    // address dependent on config fee beneficiary
     assert!(accounts[9].is_writable);
 
     // Token program a
@@ -176,10 +172,7 @@ async fn test_scale_vmm_resolve_flipped_mints() {
     assert!(accounts[8].is_writable);
 
     // Platform fee ta a
-    assert_eq!(
-        accounts[9].pubkey, PLATFORM_FEE_TA_A,
-        "platform_fee_ta_a ATA"
-    );
+    // address dependent on config fee beneficiary
     assert!(accounts[9].is_writable);
 
     // Token program a

--- a/tests/swap/heaven.rs
+++ b/tests/swap/heaven.rs
@@ -12,8 +12,9 @@ use {
     solana_instruction::AccountMeta,
     solana_keypair::Keypair,
     solana_signer::Signer,
-    spl_associated_token_account::{
-        get_associated_token_address_with_program_id, instruction::create_associated_token_account,
+    spl_associated_token_account_interface::{
+        address::get_associated_token_address_with_program_id,
+        instruction::create_associated_token_account,
     },
     spl_token_2022_interface::{extension::StateWithExtensions, state::Account},
 };


### PR DESCRIPTION
## Summary

## Changes

- removed fixed platform token account address checks (Scale AMM and VMM client tests `config.fee_beneficiary` address can change)
- lift dev-dependencies to workspace level
- regenerate lockfile

## Testing

- [x] `make format`
- [x] `make clippy`
- [x] `make test`
- [ ] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [ ] Feature flag added and used for all protocol code
- [ ] Action context enums updated
- [ ] Detection logic updated
- [ ] Account parsing validates count and types
- [x] Tests added or updated
