### PR TITLE
fix: upstream build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
   rust_test_upstream:
     name: Tests upstream
     runs-on: ubuntu-latest
-    if: false  # This job is disabled until upstream is fixed
     steps:
       - uses: actions/checkout@v6
       - uses: actions/cache@v5
@@ -99,5 +98,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: sbpf-linker
+          fallback: cargo-install
       - name: Run tests
         run: make test-upstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
  "pinocchio",
  "pinocchio-token",
  "pinocchio-token-2022",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,9 @@ solana-account-decoder-client-types = "3"
 solana-account-view = "2.0.0"
 solana-address = "2.0.0"
 solana-clock = "3.0.0"
-solana-define-syscall = "4.0.1"
+solana-define-syscall = { version = "5.1.0", features = [
+    "unstable-static-syscalls",
+] }
 solana-instruction = "3.1.0"
 solana-instruction-view = "2.1.0"
 solana-keypair = "3.1.0"

--- a/program-test/.cargo/config.toml
+++ b/program-test/.cargo/config.toml
@@ -7,6 +7,8 @@ rustflags = [
     "-C",
     "save-temps",
     "-C",
+    "lto=off",
+    "-C",
     "link-arg=--llvm-args=-bpf-stack-size=4096",
     "-C",
     "relocation-model=static",


### PR DESCRIPTION
## Summary

## Changes

- Minor updates to fix upstream build issues
- Re-enable `rust_test_upstream` CI job

cc @Aursen @clairechingching

## Testing

- [x] `make format`
- [x] `make clippy`
- [x] `make test`
- [x] `make test-upstream` (if relevant)

## Protocol integration checklist (if applicable)

- [ ] Feature flag added and used for all protocol code
- [ ] Action context enums updated
- [ ] Detection logic updated
- [ ] Account parsing validates count and types
- [ ] Tests added or updated
